### PR TITLE
Fix wrong commnad in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ requirement fq-pie(https://github.com/hironoriokano/fq-pie.git)
 	# git clone https://github.com/hironoriokano/iproute2_fq-pie.git
 	# cd iproute2_fq-pie
 	# ./install.sh
-	# tc qdisc show eth0
+	# tc qdisc show dev eth0
 	# tc qdisc add dev eth0 root fq_pie limit 100 
 	# tc qdisc change dev eth0 root fq_pie limit 200 target 10ms
 	# tc qdisc del dev eth0 root


### PR DESCRIPTION
I tested `tc qdisc show eth0` command both in centos7 and ubuntu15.0.4. This commnad gave me error. It misses `dev`.

```
root@ubuntu:/# tc qdisc show eth0
What is "eth0"? Try "tc qdisc help".
```

```
[ken@centos ~]$ tc qdisc show enp2s0f0
What is "enp2s0f0"? Try "tc qdisc help".
```
